### PR TITLE
Improve top-down player movement

### DIFF
--- a/game/player/base_player.gd
+++ b/game/player/base_player.gd
@@ -10,7 +10,7 @@ const FLY_SPEED_FACTOR= 4.0
 @export var top_down_mode: bool= false
 
 @export_category("Movement")
-@export var speed: float = 100.0
+@export var speed: float = 200.0
 @export var jump_velocity: float = -300.0
 @export var mining_speed: float= 1.0
 @export var swim_speed: float= 30.0
@@ -186,11 +186,21 @@ func sidescroll_movement(delta):
 	move_and_slide()
 
 
-func top_down_movement(delta):
-	var move_axis= Input.get_axis("down", "up")
-	velocity= look_pivot.global_transform.x * move_axis * get_max_speed()
-	move_and_slide()
+func top_down_movement(_delta):
+	var direction = Input.get_vector("left", "right", "up", "down")
+	if direction.length() > 0:
+		velocity = direction.normalized() * get_max_speed() * 1.5
+		on_movement_walk()
+	else:
+		velocity = Vector2.ZERO
+		on_movement_stop()
 	
+	# Update look_pivot only if character should still face mouse
+	var mouse_pos: Vector2 = get_global_mouse_position()
+	look_pivot.look_at(mouse_pos)
+	
+	move_and_slide()
+
 
 func jump():
 	has_jumped = true

--- a/game/player/characters/TopDownO/top_down_o.gd
+++ b/game/player/characters/TopDownO/top_down_o.gd
@@ -5,6 +5,11 @@ extends BasePlayer
 @onready var animation_player_feet = $"AnimationPlayer Feet"
 
 
+func _process(_delta):
+	if velocity.length() > 0:
+		# When moving, update the body rotation to match the movement direction
+		body.rotation = velocity.angle()
+
 
 func on_movement_jump():
 	animation_player_feet.play("jump")

--- a/game/player/characters/TopDownO/top_down_o.tscn
+++ b/game/player/characters/TopDownO/top_down_o.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=8 format=3 uid="uid://erv3wg0p6mo4"]
+[gd_scene load_steps=13 format=3 uid="uid://erv3wg0p6mo4"]
 
 [ext_resource type="PackedScene" uid="uid://d4mufsk5s6ksm" path="res://game/player/base_player.tscn" id="1_77cjs"]
 [ext_resource type="Script" path="res://game/player/hand.gd" id="2_875cp"]
@@ -69,6 +69,76 @@ _data = {
 "mine": SubResource("Animation_ysijm")
 }
 
+[sub_resource type="Animation" id="Animation_1dm2i"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("Body/Torso:rotation")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [0.0]
+}
+
+[sub_resource type="Animation" id="Animation_7fwcn"]
+resource_name = "jump"
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("Body/Torso:rotation")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.1, 0.6),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [0.0, 0.2, 0.0]
+}
+
+[sub_resource type="Animation" id="Animation_v8cep"]
+resource_name = "walk"
+length = 0.4
+loop_mode = 1
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("Body/Torso:rotation")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.1, 0.2, 0.3),
+"transitions": PackedFloat32Array(1, 1, 1, 1),
+"update": 0,
+"values": [0.0, -0.1, 0.0, 0.1]
+}
+
+[sub_resource type="Animation" id="Animation_exi4f"]
+resource_name = "enter_vehicle"
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("Body/Torso:rotation")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.5),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [0.0, 0.0]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_ve3ko"]
+_data = {
+"RESET": SubResource("Animation_1dm2i"),
+"enter_vehicle": SubResource("Animation_exi4f"),
+"jump": SubResource("Animation_7fwcn"),
+"walk": SubResource("Animation_v8cep")
+}
+
 [node name="TopDownO" node_paths=PackedStringArray("body", "look_pivot", "main_hand", "interaction_area") instance=ExtResource("1_77cjs")]
 script = ExtResource("2_a7vgm")
 top_down_mode = true
@@ -130,6 +200,11 @@ shape = SubResource("CircleShape2D_yr4g8")
 [node name="AnimationPlayer Hand" type="AnimationPlayer" parent="." index="6"]
 libraries = {
 "": SubResource("AnimationLibrary_wjf6x")
+}
+
+[node name="AnimationPlayer Feet" type="AnimationPlayer" parent="." index="7"]
+libraries = {
+"": SubResource("AnimationLibrary_ve3ko")
 }
 
 [connection signal="release_charge" from="State Machine/Item Charging" to="State Machine" method="release_charge"]


### PR DESCRIPTION
Made top down player movement work more like traditional top down 2d games with directional movement instead of moving towards mouse cursor position as it was before. Increased player movement speed since it was really really slow. Added missing animations. The player still faces the cursor position when not in motion for mining.